### PR TITLE
bump to 0.41.4 to address CVE-2021-44228 for log4j

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM metabase/metabase:v0.41.2
+FROM metabase/metabase:v0.41.4


### PR DESCRIPTION
Per https://github.com/metabase/metabase/releases/tag/v0.41.4